### PR TITLE
(MAINT) Fix debts

### DIFF
--- a/characters/nobu-oupsee-knightly-seamster.fari.json
+++ b/characters/nobu-oupsee-knightly-seamster.fari.json
@@ -78,7 +78,7 @@
                                             "id": "92cf613b-ebd9-437b-98a5-a76525946999",
                                             "label": "SILVER OWED TO Burt Heelsaw",
                                             "type": "Numeric",
-                                            "value": "999",
+                                            "value": "1700",
                                             "meta": {
                                                 "helperText": "Burt Heelsaw paid up front for a fancy garment that you have absolutely no idea how to make"
                                             }

--- a/characters/nobu-oupsee-knightly-seamster.md
+++ b/characters/nobu-oupsee-knightly-seamster.md
@@ -16,7 +16,7 @@
 
 ### Debts
 
-- 999 to Burt Heelsaw: Burt Heelsaw paid up front for a fancy garment that you have absolutely no idea how to make
+- 1700 to Burt Heelsaw: Burt Heelsaw paid up front for a fancy garment that you have absolutely no idea how to make
 
 ## Domains
 

--- a/characters/punished-mattheas-indebted-penitent.fari.json
+++ b/characters/punished-mattheas-indebted-penitent.fari.json
@@ -79,7 +79,7 @@
                                             "id": "12e4eec5-8cf6-4e00-90f7-875654187f78",
                                             "label": "SILVER OWED TO (The Church)",
                                             "type": "Numeric",
-                                            "value": "999",
+                                            "value": "1400",
                                             "meta": {
                                                 "helperText": "Gambling debts owed to the church, but specifically Deacon Eavesnest, who is a bigger cheat than even you."
                                             }

--- a/characters/punished-mattheas-indebted-penitent.md
+++ b/characters/punished-mattheas-indebted-penitent.md
@@ -16,7 +16,7 @@
 
 ### Debts
 
-- 999 to The Church: Gambling debts owed to the church, but specifically Deacon Eavesnest, who is a bigger cheat than even you.
+- 1400 to The Church: Gambling debts owed to the church, but specifically Deacon Eavesnest, who is a bigger cheat than even you.
 
 ## Domains
 

--- a/characters/scud-ruckuss-partying-mechanic.fari.json
+++ b/characters/scud-ruckuss-partying-mechanic.fari.json
@@ -79,7 +79,7 @@
                                             "id": "0f78ce9c-1d17-4da3-b15b-58fac94d1f0b",
                                             "label": "SILVER OWED TO Bower Sanction",
                                             "type": "Numeric",
-                                            "value": "999",
+                                            "value": "1500",
                                             "meta": {
                                                 "helperText": "Medical Debt, owed to Bower Sanction, the only physician who would excise your haunted boil."
                                             }

--- a/characters/scud-ruckuss-partying-mechanic.md
+++ b/characters/scud-ruckuss-partying-mechanic.md
@@ -16,7 +16,7 @@
 
 ### Debts
 
-- 999 to Bower Sanction: Medical Debt, owed to Bower Sanction, the only physician who would excise your haunted boil.
+- 1500 to Bower Sanction: Medical Debt, owed to Bower Sanction, the only physician who would excise your haunted boil.
 
 ## Domains
 

--- a/characters/tiss-transom-slippery-entomancer.fari.json
+++ b/characters/tiss-transom-slippery-entomancer.fari.json
@@ -77,9 +77,9 @@
                                         },
                                         {
                                             "id": "423a9ea9-f8be-4dcc-ab7d-e5509402f86c",
-                                            "label": "Silve Owed to Moe Stagwhale",
+                                            "label": "Silver Owed to Moe Stagwhale",
                                             "type": "Numeric",
-                                            "value": "999",
+                                            "value": "1900",
                                             "meta": {
                                                 "helperText": "You mortgaged your expensive violin to pay for adventuring school. Moe Stagwhale will not be happy if you miss a payment.&nbsp;"
                                             }

--- a/characters/tiss-transom-slippery-entomancer.md
+++ b/characters/tiss-transom-slippery-entomancer.md
@@ -16,7 +16,7 @@
 
 ### Debts
 
-None.
+- 1900 to Moe Stagwhale: You mortgaged your expensive violin to pay for adventuring school. Moe Stagwhale will not be happy if you miss a payment.&nbsp;
 
 ## Domains
 


### PR DESCRIPTION
Several characters have more than 1000 in debt, but Fari's numeric field only goes to 999; we should show higher debts in the Markdown at least until the web UI can be fixed.